### PR TITLE
Delete fix

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -99,7 +99,8 @@ class ApplicationViews extends Component {
     DecksManager.deleteDeck(deckID)
       .then(allDecks => {
         this.setState({
-          allDecks: allDecks
+          allDecks: allDecks,
+          initialized: false
         });
       })
       .then(() => {
@@ -115,7 +116,8 @@ class ApplicationViews extends Component {
         // and now get all the cards again
         return CardManager.getAll().then(allCards => {
           this.setState({
-            allCards: allCards
+            allCards: allCards,
+            initialized: true
           });
         });
       })

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,5 +1,6 @@
 import { Route } from "react-router-dom";
 import React, { Component } from "react";
+import { Loader, Segment, Dimmer } from "semantic-ui-react";
 import Home from "./home/Home";
 import Login from "./authentication/Login";
 import Register from "./authentication/Registration";
@@ -120,7 +121,7 @@ class ApplicationViews extends Component {
             initialized: true
           });
         });
-      })
+      });
     //   ^ think I need to return a promise here for .then to work in deck detail (for history push)
   };
 
@@ -212,7 +213,7 @@ class ApplicationViews extends Component {
                   updateCard={this.updateCard}
                   updateDeck={this.updateDeck}
                   postNewCard={this.postNewCard}
-                //   history={this.history}
+                  //   history={this.history}
                 />
               );
             }}
@@ -220,7 +221,15 @@ class ApplicationViews extends Component {
         </React.Fragment>
       );
     } else {
-      return <React.Fragment>loading...</React.Fragment>;
+      return (
+        <React.Fragment>
+          <Segment>
+            <Dimmer active inverted>
+              <Loader inverted>Loading</Loader>
+            </Dimmer>
+          </Segment>
+        </React.Fragment>
+      );
     }
   }
 }

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -93,23 +93,33 @@ class ApplicationViews extends Component {
 
   // delete decks and relist - but also delete the cards associated with that deck
   deleteDeckAndCards = deckID => {
-    // commenting out briefly so I can test card deleting
-    // then try to get all of it inside one fetch call
     // consider setting initialized state to false until the data comes back
     // and also history.push to maindeck page
 
-    DecksManager.deleteDeck(deckID).then(allDecks => {
-      this.setState({
-        allDecks: allDecks
-      });
-    });
-
-    // commenting out for now because this is giving a 404 error
-    CardManager.deleteCardsInDeck(deckID).then(allCards => {
-      this.setState({
-        allCards: allCards
-      });
-    });
+    DecksManager.deleteDeck(deckID)
+      .then(allDecks => {
+        this.setState({
+          allDecks: allDecks
+        });
+      })
+      .then(() => {
+        // run forEach over allCards - if the card is in the deck we're deleting, delete that card too
+        this.state.allCards.forEach(card => {
+          if (card.deckID === deckID) {
+            // console.log(card)
+            this.deleteCard(card.id);
+          }
+        });
+      })
+      .then(() => {
+        // and now get all the cards again
+        return CardManager.getAll().then(allCards => {
+          this.setState({
+            allCards: allCards
+          });
+        });
+      })
+    //   ^ think I need to return a promise here for .then to work in deck detail (for history push)
   };
 
   updateCard = (payload, url) => {
@@ -200,6 +210,7 @@ class ApplicationViews extends Component {
                   updateCard={this.updateCard}
                   updateDeck={this.updateDeck}
                   postNewCard={this.postNewCard}
+                //   history={this.history}
                 />
               );
             }}

--- a/src/components/view/DeckDetail.js
+++ b/src/components/view/DeckDetail.js
@@ -97,6 +97,9 @@ export default class DeckDetail extends Component {
           content="Delete Deck"
           onClick={() => {
             this.props.deleteDeckAndCards(deck.id);
+            this.props.history.push("/maindeck");
+            // ^ tried doing a .then here, but not working right now
+            // might need to return a promise from deleteDeckAndCards?
           }}
         />
       );


### PR DESCRIPTION
Just two main fixes in this branch.

1. Fixed delete deck - now when user deletes a deck, all associated cards are also deleted. I had to use a forEach loop over allCards to accomplish this. Then all cards are fetched and state is reset again. When delete deck is complete, the user is pushed back to the main deck page.

2. Added a loader from Semantic UI that displays when page is loading. Small fix but it's a little more aesthetically pleasing.