### PR TITLE
Deck sort refactor

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -222,6 +222,7 @@ class ApplicationViews extends Component {
                   publicDecks={this.state.publicDecks}
                   userDecks={this.state.userDecks}
                   postNewDeck={this.postNewDeck}
+                  allDecks={this.state.allDecks}
                 />
               );
             }}

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -25,6 +25,12 @@ class ApplicationViews extends Component {
 
   // IDEA: run sort on ComponentWillMount - fetch all decks, then use that to fill userDecks and publicDecks
 
+  //   componentWillMount() {
+  //     const currentUser = parseInt(sessionStorage.getItem("userID"));
+
+  //     DecksManager.getUserDecks(currentUser).then((data) => console.log(data))
+  //   }
+
   componentDidMount() {
     const currentUser = parseInt(sessionStorage.getItem("userID"));
     this.setState({
@@ -139,9 +145,30 @@ class ApplicationViews extends Component {
   // leaving it for now (just to get update functional) but this needs to be addressed
 
   updateDeck = (payload, url) => {
-    DecksManager.patchAndListDecks(payload, url).then(allDecks => {
-      this.setState({ allDecks: allDecks });
-    });
+    console.log(payload);
+
+    let patchAndListAllDecks = DecksManager.patchAndListDecks(payload, url);
+
+    let relistUserDecks = DecksManager.getUserDecks(this.state.currentUser);
+
+    // Promise.all([patchAndListAllDecks, relistUserDecks]).then(data => {
+    //   console.log(data);
+    //   this.setState({
+    //     allDecks: data[0],
+    //     userDecks: data[1]
+    //   });
+    // });
+
+    // does promise all wait for 1 to work before 2? no! so.....
+    // trying it with a callback!
+
+    patchAndListAllDecks.then(data =>
+      this.setState({ allDecks: data }, () => {
+        relistUserDecks.then(userDecks => {
+          this.setState({ userDecks: userDecks });
+        });
+      })
+    );
   };
 
   postNewDeck = payload => {
@@ -225,7 +252,14 @@ class ApplicationViews extends Component {
             exact
             path="/flashcard"
             render={props => {
-              return <Flashcard {...props} users={this.state.users} allCards={this.state.allCards} allDecks={this.state.allDecks}/>;
+              return (
+                <Flashcard
+                  {...props}
+                  users={this.state.users}
+                  allCards={this.state.allCards}
+                  allDecks={this.state.allDecks}
+                />
+              );
             }}
           />
         </React.Fragment>

--- a/src/components/view/MainDeck.js
+++ b/src/components/view/MainDeck.js
@@ -120,7 +120,7 @@ export default class MainDeck extends Component {
             </Modal>
           </div>
 
-          {this.props.userDecks.map(deck => {
+          {/* {this.props.userDecks.map(deck => {
             return (
               <Card color="green" href={`/maindeck/${deck.id}`} key={deck.id}>
                 <Card.Content>
@@ -129,6 +129,19 @@ export default class MainDeck extends Component {
                 </Card.Content>
               </Card>
             );
+          })} */}
+
+          {this.props.allDecks.map(deck => {
+            if (deck.userID === this.props.currentUser) {return (
+              <Card color="green" href={`/maindeck/${deck.id}`} key={deck.id}>
+                <Card.Content>
+                  <Card.Header>{deck.name}</Card.Header>
+                  <Card.Description>{deck.description}</Card.Description>
+                </Card.Content>
+              </Card>
+            )} else {
+              return null
+            };
           })}
         </div>
       </React.Fragment>


### PR DESCRIPTION
This branch was a (relatively) quick fix - I refactored the way Main Deck displays private decks, because I was having trouble updating state on User Decks. I believe it was a timing issue. I attempted a Promise.all and also a callback, but timing still wasn't quite right, so I did it this way. Everything is now working properly with update/new/delete displaying correctly.